### PR TITLE
Remove Docker layer cache GH Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,23 +20,6 @@ jobs:
         run: |
           ./run ci:install-deps
 
-      # -----------------------------------------------------------------------
-      # Github Actions does not support Docker layer caching out of the box.
-      # This means every build will be 7+ minutes unless we cache things.
-      #
-      # We'll be using a 3rd party action to handle caching Docker layers.
-      #
-      # It's also recommended to pull images you need before caching since it
-      # ends up being faster than reading from the cache.
-      - name: "Pull required official Docker images before we cache layers"
-        run: |
-          cp --no-clobber .env.example .env
-          docker-compose pull postgres redis
-
-      - uses: "satackey/action-docker-layer-caching@v0.0.11"
-        continue-on-error: true
-      # -----------------------------------------------------------------------
-
       - name: "Test"
         run: |
           # Remove volumes in CI to avoid permission errors due to UID / GID.


### PR DESCRIPTION
There seems to be a bug with this action that's causing GitHub to say there's no space left on the CI runner.

Here's a screenshot of what the error says in the action when this occurs:

![image](https://user-images.githubusercontent.com/813219/108611887-1396fd00-73b1-11eb-994c-02cf7319d96a.png)
