### PR TITLE
Upgrade bundler to fix platform resolution issue on arm64

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.7.1)
     minitest (5.15.0)
     msgpack (1.4.4)
     net-imap (0.2.3)
@@ -132,6 +133,11 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
+      racc (~> 1.4)
+    nokogiri (1.13.1-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     pg (1.2.3)
@@ -219,6 +225,8 @@ GEM
     zeitwerk (2.5.3)
 
 PLATFORMS
+  aarch64-linux
+  ruby
   x86_64-linux
 
 DEPENDENCIES
@@ -246,4 +254,4 @@ RUBY VERSION
    ruby 3.1.0p0
 
 BUNDLED WITH
-   2.3.3
+   2.3.6


### PR DESCRIPTION
Bundler 2.3.3 has a bug that fails to resolve platforms https://github.com/rubygems/rubygems/issues/5088. This issue occurs on Mac and Debian arm64, and this patch to upgrade bundler resolves it by upgrading to the latest bundler.