### PR TITLE
`Redis.current=` is deprecated and will be removed in 5.0

### DIFF
--- a/app/controllers/up_controller.rb
+++ b/app/controllers/up_controller.rb
@@ -4,7 +4,7 @@ class UpController < ApplicationController
   end
 
   def databases
-    Redis.current.ping
+    $redis.ping
     ActiveRecord::Base.connection.execute("SELECT 1")
 
     head :ok

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,1 +1,1 @@
-Redis.current = Redis.new(url: ENV.fetch("REDIS_URL") { "redis://redis:6379/1" })
+$redis = Redis.new(url: ENV.fetch("REDIS_URL") { "redis://redis:6379/1" })


### PR DESCRIPTION
While running through the `README`, I noticed this deprecation warning:

    ./run rails db:setup
    # `Redis.current=` is deprecated and will be removed in 5.0. (called from: /app/config/initializers/redis.rb:1:in `<main>')
    #    (138.5ms)  CREATE DATABASE "hello_development" ENCODING = 'unicode'
    # Created database 'hello_development'
    #    ...
    #    ...
    #    ...

I have just started dabbling with your template, but from a
glance it seems like you only use `Redis.current`:

1.  in the redis initializer, to set the `Redis.current` value.
2.  in the health-check controller, to ping redis.

It seems like all other redis integrations use `REDIS_URL` directly,
so they would not be impacted by leaving `Redis.current` as `nil`.

Possible fixes I see include:

1.  set a global `$redis` in the initializer, use that `$redis` in place of `Redis.current`

    or

2.  in-line `Redis.new(url: ENV.fetch("REDIS_URL"))` wherever you need to

I can see a case for either, but this commit implements the global
variable version. I'm happy to in-line if that's the preferred pattern
to establish in your template