### PR TITLE
Update Node and Yarn install strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Add `required: false` to `depends_on` in `docker-compose.yml` (requires Docker Compose v2.20.2+)
+- Update Node and Yarn install strategy to remove install script deprecation warning
 
 #### Languages and services
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ ARG GID=1000
 
 RUN bash -c "set -o pipefail && apt-get update \
   && apt-get install -y --no-install-recommends build-essential curl git libpq-dev \
-  && curl -sSL https://deb.nodesource.com/setup_20.x | bash - \
-  && curl -sSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-  && echo 'deb https://dl.yarnpkg.com/debian/ stable main' | tee /etc/apt/sources.list.d/yarn.list \
-  && apt-get update && apt-get install -y --no-install-recommends nodejs yarn \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key -o /etc/apt/keyrings/nodesource.asc \
+  && echo 'deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesource.com/node_20.x nodistro main' | tee /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update && apt-get install -y --no-install-recommends nodejs \
+  && corepack enable \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man \
   && apt-get clean \
   && groupadd -g \"${GID}\" ruby \


### PR DESCRIPTION
I'm back with more Node updates :)

I noticed this while working on my other PR.

<img width="950" alt="Screenshot 2023-09-08 at 8 41 13 PM" src="https://github.com/nickjj/docker-rails-example/assets/36681963/ad6cbf62-552c-42bb-8013-2b3286f0b414">

Node makes you wait a whole 60 seconds as punishment for using a deprecated script.

From the [nodesource github repo](https://github.com/nodesource/distributions):

> The installation scripts setup_XX.x are no longer supported and are not needed anymore, as the installation process is straightforward for any RPM and DEB distro.

I copied and pasted their installation instructions exactly.

From the [yarn website](https://yarnpkg.com/getting-started/install#installing-the-latest-build-fresh-from-master):

> The preferred way to manage Yarn is by-project and through [Corepack](https://nodejs.org/dist/latest/docs/api/corepack.html), a tool shipped by default with Node.js. Modern releases of Yarn aren't meant to be installed globally, or from npm.

To enable Yarn apparently all you have to do is enable Corepack.