### PR TITLE
Delete the contents of the /tmp directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `required: false` to `depends_on` in `docker-compose.yml` (requires Docker Compose v2.20.2+)
 - Update Node and Yarn install strategy to remove install script deprecation warning
 - A whole bunch of changes related to Rails 7.1.0, take a look at [this commit](https://github.com/nickjj/docker-rails-example/commit/94e9190e2e3db2cd350cd217db3b270b7c77fb72)
+- Update `rename-project` script to auto-delete temporary files
 
 #### Languages and services
 

--- a/README.md
+++ b/README.md
@@ -280,11 +280,6 @@ docker compose up --build
 ./run rails db:setup
 ```
 
-*If you get an error upping the project related to `RuntimeError: invalid
-bytecode` then you have old `tmp/` files sitting around related to the old
-project name, you can run `./run clean` to clear all temporary files and fix
-the error.*
-
 #### Sanity check to make sure the tests still pass:
 
 It's always a good idea to make sure things are in a working state before

--- a/bin/rename-project
+++ b/bin/rename-project
@@ -43,12 +43,13 @@ while true; do
 done
 
 # -----------------------------------------------------------------------------
-# The core of the script which renames a few things.
+# The core of the script.
 # -----------------------------------------------------------------------------
 find . -type f -exec \
   perl -i \
     -pe "s/(${FIND_APP_NAME}${FIND_FRAMEWORK}|${FIND_APP_NAME})/${APP_NAME}/g;" \
     -pe "s/${FIND_MODULE_NAME}/${MODULE_NAME}/g;" {} +
+find tmp/ -mindepth 1 ! -name ".keep" -delete
 # -----------------------------------------------------------------------------
 
 cat << EOF


### PR DESCRIPTION
Cached files in the /tmp directory can cause errors after renaming the project--nuke them so they don't cause grief.