### PR TITLE
Expose the DB port to the host machine so it's easy to use tools like TablePlus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,7 @@ export POSTGRES_PASSWORD=password
 #export POSTGRES_DB=hello
 #export POSTGRES_HOST=postgres
 #export POSTGRES_PORT=5432
+#export POSTGRES_PORT_FORWARD=127.0.0.1:5499
 
 # What's your full Redis connection URL? This will be used for caching, Sidekiq,
 # and Action Cable. You can always split them up later.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ variables to fix this.
 
 Visit <http://localhost:8000> in your favorite browser.
 
+### Connect to the Database with tools like TablePlus/DBeaver:
+
+By default we expose the internal port 5432 (default PostgreSQL port) to the
+external world through the port 5499.
+Connect to 127.0.0.1:5499, with the user `hello` and the password `password`.
+
 #### Running the test suite:
 
 ```sh

--- a/compose.yaml
+++ b/compose.yaml
@@ -57,6 +57,8 @@ services:
     stop_grace_period: "3s"
     volumes:
       - "postgres:/var/lib/postgresql/data"
+    ports:
+      - "${POSTGRES_PORT_FORWARD:-127.0.0.1:5499}:${POSTGRES_PORT:-5432}"
 
   redis:
     deploy:


### PR DESCRIPTION
During development, it's very convenient to connect to the database using tools like TablePlus. I think these tools are very helpful for developers to quickly get feedback on the data they're working with.