### PR TITLE
Build js assets on the js container instead of the host machine

### DIFF
--- a/run
+++ b/run
@@ -119,7 +119,7 @@ function yarn:build {
     args=(--sourcemap --watch)
   fi
 
-  esbuild app/javascript/*.* --outdir=app/assets/builds --bundle "${args[@]}"
+  _build_run_down js ./node_modules/esbuild/bin/esbuild app/javascript/*.* --outdir=app/assets/builds --bundle "${args[@]}"
 }
 
 function yarn:build:css {


### PR DESCRIPTION
Currently `./run yarn:build` is using the host's version of esbuild to build the js assets. Our project uses linux containers, but our devs have Mac hosts, and we got errors like the one below during the build process.

```
info @parcel/watcher-android-arm64@2.5.0: The platform "darwin" is incompatible with this module.
info "@parcel/watcher-android-arm64@2.5.0" is an optional dependency and failed compatibility check. Excluding it from installation.
```

I modified the run script to build the js assets on the container instead of the host. Offering this here, in case it is useful. 

Thank you for your amazing work!