### PR TITLE
feature: cleanup tmp PID file

### DIFF
--- a/bin/docker-entrypoint-web
+++ b/bin/docker-entrypoint-web
@@ -6,4 +6,7 @@ set -e
 # into your volume persisted public directory.
 cp -r /public /app
 
+# This shouldn't be here, but failing to shutdown properly might leave this
+rm -f /app/tmp/pids/server.pid
+
 exec "$@"


### PR DESCRIPTION
I believe this might make the repo a little more resilient to (my) bad improper container shutdown habits, would you accept this upstream?